### PR TITLE
fix applet params schema crashing when two applets use the same name

### DIFF
--- a/kernel/lib/completions.ts
+++ b/kernel/lib/completions.ts
@@ -123,9 +123,16 @@ async function chooseActions(
       return {
         type: 'object',
         description: `An object that adheres to the chosen tool's params schema.`,
-        properties: indexedAction.action.params,
+        properties: {
+          _type: {
+            type: 'string',
+            description: 'Unique discriminator for the params schema.',
+            enum: [indexedAction.key],
+          },
+          ...indexedAction.action.params,
+        },
         additionalProperties: false,
-        required: Object.keys(indexedAction.action.params),
+        required: ['_type', ...Object.keys(indexedAction.action.params)],
       };
     });
 
@@ -152,6 +159,7 @@ async function chooseActions(
           },
           params: {
             anyOf: paramsSchemas,
+            discriminator: { propertyName: '_type' },
           },
         },
       },

--- a/kernel/lib/completions.ts
+++ b/kernel/lib/completions.ts
@@ -124,15 +124,15 @@ async function chooseActions(
         type: 'object',
         description: `An object that adheres to the chosen tool's params schema.`,
         properties: {
-          _type: {
+          key: {
             type: 'string',
-            description: 'Unique discriminator for the params schema.',
+            description: 'Unique discriminator key for the params schema.',
             enum: [indexedAction.key],
           },
           ...indexedAction.action.params,
         },
         additionalProperties: false,
-        required: ['_type', ...Object.keys(indexedAction.action.params)],
+        required: ['key', ...Object.keys(indexedAction.action.params)],
       };
     });
 
@@ -159,7 +159,7 @@ async function chooseActions(
           },
           params: {
             anyOf: paramsSchemas,
-            discriminator: { propertyName: '_type' },
+            discriminator: { propertyName: 'key' },
           },
         },
       },


### PR DESCRIPTION
When two applets have the same param name (e.g query), the `anyOf` fails to discriminate between them, causing the `completions` endpoint to crash out.

Add a `_type` property for each indexed action, using the `key`. This _type is then used with the `anyOf` as the `discriminator` property.

Error:
```
Error: 400 Invalid schema: Objects provided via 'anyOf' must not share identical first keys. Consider adding a discriminator key or rearranging the properties to ensure the first key is unique.
```