### PR TITLE
fix(kernel): stringify actions data in prompt

### DIFF
--- a/kernel/lib/completions.ts
+++ b/kernel/lib/completions.ts
@@ -91,7 +91,7 @@ async function chooseActions(
 
   const prompt = `\
     In this environment you have access to a set of tools. Here are the functions available in JSONSchema format:
-    ${actions}
+    ${JSON.stringify(actions)}
     Choose one or more functions to call to respond to the user's query.
   `;
 


### PR DESCRIPTION
## What happens

The kernel sometimes sends out prompts containing "[object Object]".

## What is expected

Data must be properly stringified before embedded into prompts.

## Screenshot

### Before
![Screenshot From 2025-02-05 19-39-09](https://github.com/user-attachments/assets/6316a8cc-bce5-4d65-ae14-1158da2259c6)
Objects are improperly stringified into `[object Object]`.

### After
![Screenshot From 2025-02-05 19-38-58](https://github.com/user-attachments/assets/4c8c7ac6-15bc-4a2e-abf9-7f37e6082d08)
The prompt includes properly stringified JSON data.
