### PR TITLE
Fix dev scripts & documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ An experimental client for the web from [Unternet](https://unternet.co).
 
 ## Setup
 
+- clone the [Web Applets Repo](https://github.com/depatchedmode/web-applets) to the same directory as the Operator Repo. Run `npm build` from the `/sdk` directory so those modules are available.
 - Add a `.env` file at `web/.env` and set `VITE_OPENAI_API_KEY=<your-openai-api-key>`.

--- a/native/package.json
+++ b/native/package.json
@@ -7,8 +7,8 @@
   "author": "Rupert Manfredi <rupert@unternet.co>",
   "homepage": "https://unternet.co",
   "scripts": {
-    "dev": "electron .",
-    "package": "todesktop build"
+    "dev": "npx electron .",
+    "package": "npx todesktop build"
   },
   "license": "ISC",
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build"
+    "dev": "npx vite",
+    "build": "npx vite build"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
While getting setup, realized that a few scripts depended on global module installs rather than the local resources, and that the code expects the Web Applets repo to be built locally.

This fixes those two issues.