### PR TITLE
fix(parameters): check for empty object

### DIFF
--- a/kernel/lib/completions.ts
+++ b/kernel/lib/completions.ts
@@ -103,7 +103,7 @@ async function chooseActions(
       required: ['id'],
     };
 
-    if (action.parameters) {
+    if (action.parameters && Object.keys(action.parameters).length > 0) {
       schema.properties.arguments = action.parameters;
 
       // Set some variables that OpenAI requires if they're not present


### PR DESCRIPTION
Sometimes there are no keys here and it should skip the code block if that's the case